### PR TITLE
Update to new mbed-mqtt library

### DIFF
--- a/MQTT.lib
+++ b/MQTT.lib
@@ -1,1 +1,0 @@
-https://mbed.org/teams/mqtt/code/MQTT/#9cff7b6bbd01

--- a/mbed-mqtt.lib
+++ b/mbed-mqtt.lib
@@ -1,0 +1,1 @@
+https://github.com/ARMmbed/mbed-mqtt

--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#6a0a86538c0b9b2bfcc4583b1e2b7fea8f4e71e9
+https://github.com/ARMmbed/mbed-os/#51d55508e8400b60af467005646c4e2164738d48


### PR DESCRIPTION
The existing [MQTT library](https://os.mbed.com/teams/mqtt/) has been replaced by a new [mbed-mqtt](https://github.com/ARMmbed/mbed-mqtt) library.
The new library also uses [Paho's embedded C MQTT](https://github.com/eclipse/paho.mqtt.embedded-c) protocol implementation, but is actively supported, covered with greentea tests and is integrated with Mbed OS `Socket` API.
I have updated the connection code and checked that I can still talk to the cloud, as described in the README.